### PR TITLE
Fix gem stat requirements

### DIFF
--- a/RePoE/gems.py
+++ b/RePoE/gems.py
@@ -214,7 +214,7 @@ class GemConverter:
                     print("Unknown multiplier (50) for " + gepl['GrantedEffectsKey']['Id'])
                     req = 0
                 else:
-                    req = gem_stat_requirement(level, gtype, multi)
+                    req = gem_stat_requirement(gepl['LevelRequirement'], gtype, multi)
                 stat_requirements[stat_type] = req
             r['stat_requirements'] = stat_requirements
 


### PR DESCRIPTION
First argument to `gem_stat_requirement` should be required character level, not gem level. Currently stat requirements are calculated incorrectly, resulting in 50 int/dex/str requirements for level 20 skill gems.