### PR TITLE
add in json files to global variables

### DIFF
--- a/RePoE/__init__.py
+++ b/RePoE/__init__.py
@@ -1,35 +1,61 @@
 import json
 import os
 
+from RePoE.parser.modules.base_items import base_items
+from RePoE.parser.modules.crafting_bench_options import crafting_bench_options
 
-def _get_file_path_from_data_dir(file_name):
-    this_dir, _ = os.path.split(__file__)
-    DATA_PATH = os.path.join(this_dir, "data", file_name)
-    return DATA_PATH
+#directory that this __init__ file lives in
+__REPOE_DIR__, _ = os.path.split(__file__)
+
+#full path to ./data
+__DATA_PATH__ = os.path.join(__REPOE_DIR__, "data", "")
+
+def load_json(json_file_path):
+    file_path = __DATA_PATH__ + f"{json_file_path}"
+    with open(file_path) as json_data:
+        try:
+            return json.load(json_data)
+        except json.decoder.JSONDecodeError:
+            print(
+                f"Warning: {json_file_path} failed to decode json \n Recommended to execute run_parser.py to fix"
+            )
+
+base_items = load_json("base_items.json")
+characters = load_json("characters.json")
+crafting_bench_options = load_json("crafting_bench_options.json")
+default_monster_stats = load_json("default_monster_stats.json")
+essences = load_json("essences.json")
+fossils = load_json("fossils.json")
+gems = load_json("gems.json")
+gem_tags = load_json("gem_tags.json")
+gem_tooltips = load_json("gem_tooltips.json")
+item_classes = load_json("item_classes.json")
+mods = load_json("mods.json")
+mod_types = load_json("mod_types.json")
+quest_rewards = load_json("quest_rewards.json")
+stats = load_json("stats.json")
+stat_translations = load_json("stat_translations.json")
+tags = load_json("tags.json")
+vendor_rewards = load_json("vendor_rewards.json")
+
 
 
 def _get_all_json_files():
+    """get all json files in /data"""
     json_files = [
         pos_json
-        for pos_json in os.listdir(_get_file_path_from_data_dir(""))
+        for pos_json in os.listdir(__DATA_PATH__)
         if pos_json.endswith(".json") and not pos_json.endswith(".min.json")
     ]
     return json_files
 
-
-def add_jsons_to_global():
-    for json_string in _get_all_json_files():
-        file_path = _get_file_path_from_data_dir(json_string)
-        with open(file_path) as json_data:
-            try:
-                globals()[json_string[:-5]] = json.load(json_data)
-            except json.decoder.JSONDecodeError:
-                print(
-                    f"Warning: {json_string} failed to decode json \n Recommended to execute run_parser.py to fix"
-                )
-
-
-add_jsons_to_global()
+def _assert_all_json_files_accounted_for():
+    json_files = _get_all_json_files()
+    for json_file in json_files:
+        json_file_stripped = json_file[:-5]
+        assert json_file_stripped in globals(), f"the following json file needs to be added to __init__ load: {json_file}"
+        
+_assert_all_json_files_accounted_for()
 
 if __name__ == "__main__":
     print(characters)

--- a/RePoE/__init__.py
+++ b/RePoE/__init__.py
@@ -1,9 +1,6 @@
 import json
 import os
 
-from RePoE.parser.modules.base_items import base_items
-from RePoE.parser.modules.crafting_bench_options import crafting_bench_options
-
 #directory that this __init__ file lives in
 __REPOE_DIR__, _ = os.path.split(__file__)
 
@@ -37,7 +34,6 @@ stats = load_json("stats.json")
 stat_translations = load_json("stat_translations.json")
 tags = load_json("tags.json")
 vendor_rewards = load_json("vendor_rewards.json")
-
 
 
 def _get_all_json_files():

--- a/RePoE/run_parser.py
+++ b/RePoE/run_parser.py
@@ -1,6 +1,8 @@
 import argparse
 
-from RePoE import add_jsons_to_global
+import RePoE
+from importlib import reload
+
 from RePoE.parser.modules import get_parser_modules
 
 from RePoE.parser.util import load_ggpk, create_relational_reader, create_translation_file_cache, \
@@ -36,7 +38,9 @@ def main(data_path='./data/'):
     for parser_module in selected_modules:
         print("Running module '%s'" % parser_module.__name__)
         parser_module.write(ggpk=ggpk, data_path=data_path, relational_reader=rr, translation_file_cache=tfc, ot_file_cache=otfc)
-    add_jsons_to_global()
+    
+    #This forces the globals to be up to date with what we just parsed, in case someone uses `run_parser` within a script
+    reload(RePoE)
 
 
 


### PR DESCRIPTION
Before I tried to be too slick by having it automatically detect the json files and add them into `global()`. This has the obvious downside of not being IDE compatible.

This PR:
- Explicitly loads in the json files on `__init__` (so they are in `global()`)
- Will give a warning if one of the json files doesnt load correctly
- Will give a fatal error if one of the json files in `\data` isn't represented in `__init__` with instructions to come fix it.