### PR TITLE
import with stat_translations

### DIFF
--- a/RePoE/__init__.py
+++ b/RePoE/__init__.py
@@ -8,8 +8,8 @@ __REPOE_DIR__, _ = os.path.split(__file__)
 __DATA_PATH__ = os.path.join(__REPOE_DIR__, "data", "")
 
 
-def load_json(json_file_path):
-    file_path = __DATA_PATH__ + f"{json_file_path}"
+def load_json(json_file_path, base_path=__DATA_PATH__):
+    file_path = base_path + f"{json_file_path}"
     with open(file_path) as json_data:
         try:
             return json.load(json_data)
@@ -36,18 +36,18 @@ cluster_jewels = load_json("cluster_jewels.json")
 cluster_jewel_notables = load_json("cluster_jewel_notables.json")
 
 
-def _get_all_json_files():
+def _get_all_json_files(base_path=__DATA_PATH__):
     """get all json files in /data"""
     json_files = [
         pos_json
-        for pos_json in os.listdir(__DATA_PATH__)
+        for pos_json in os.listdir(base_path)
         if pos_json.endswith(".json") and not pos_json.endswith(".min.json")
     ]
     return json_files
 
 
-def _assert_all_json_files_accounted_for():
-    json_files = _get_all_json_files()
+def _assert_all_json_files_accounted_for(base_path=__DATA_PATH__):
+    json_files = _get_all_json_files(base_path=__DATA_PATH__)
     for json_file in json_files:
         json_file_stripped = json_file[:-5]
         assert (

--- a/RePoE/__init__.py
+++ b/RePoE/__init__.py
@@ -49,7 +49,7 @@ def _get_all_json_files(base_path=__DATA_PATH__):
 def _assert_all_json_files_accounted_for(base_path=__DATA_PATH__):
     json_files = _get_all_json_files(base_path=__DATA_PATH__)
     for json_file in json_files:
-        json_file_stripped = json_file[:-5]
+        json_file_stripped, _, _ = json_file.partition(".json")
         assert (
             json_file_stripped in globals()
         ), f"the following json file needs to be added to __init__ load: {json_file}"

--- a/RePoE/stat_translations.py
+++ b/RePoE/stat_translations.py
@@ -4,48 +4,39 @@ import os
 
 __STAT_TRANSLATION_PATH__ = os.path.join(__DATA_PATH__, "stat_translations", "")
 
-strongbox = load_json("strongbox.json", __STAT_TRANSLATION_PATH__)
-support_gem = load_json("support_gem.json", __STAT_TRANSLATION_PATH__)
-skill = load_json("skill.json", __STAT_TRANSLATION_PATH__)
-aura_skill = load_json("aura_skill.json", __STAT_TRANSLATION_PATH__)
-banner_aura_skill = load_json("banner_aura_skill.json", __STAT_TRANSLATION_PATH__)
-beam_skill = load_json("beam_skill.json", __STAT_TRANSLATION_PATH__)
-brand_skill = load_json("brand_skill.json", __STAT_TRANSLATION_PATH__)
-buff_skill = load_json("buff_skill.json", __STAT_TRANSLATION_PATH__)
-curse_skill = load_json("curse_skill.json", __STAT_TRANSLATION_PATH__)
-debuff_skill = load_json("debuff_skill.json", __STAT_TRANSLATION_PATH__)
-minion_skill = load_json("minion_skill.json", __STAT_TRANSLATION_PATH__)
-minion_attack_skill = load_json("minion_attack_skill.json", __STAT_TRANSLATION_PATH__)
-minion_spell_skill = load_json("minion_spell_skill.json", __STAT_TRANSLATION_PATH__)
-offering_skill = load_json("offering_skill.json", __STAT_TRANSLATION_PATH__)
-variable_duration_skill = load_json("variable_duration_skill.json", __STAT_TRANSLATION_PATH__)
-areas = load_json("areas.json", __STAT_TRANSLATION_PATH__)
-atlas = load_json("atlas.json", __STAT_TRANSLATION_PATH__)
-passive_skill = load_json("passive_skill.json", __STAT_TRANSLATION_PATH__)
-passive_skill_aura = load_json("passive_skill_aura.json", __STAT_TRANSLATION_PATH__)
-monster = load_json("monster.json", __STAT_TRANSLATION_PATH__)
 
-all = [
-    strongbox,
-    support_gem,
-    skill,
-    aura_skill,
-    banner_aura_skill,
-    beam_skill,
-    brand_skill,
-    buff_skill,
-    curse_skill,
-    debuff_skill,
-    minion_skill,
-    minion_attack_skill,
-    minion_spell_skill,
-    offering_skill,
-    variable_duration_skill,
-    areas,
-    atlas,
-    passive_skill,
-    passive_skill_aura,
-    monster,
-]
+stat_translations = {}
+
+
+def _load_json_and_add_to_stat_translations(path, dir):
+    name, _, _ = path.partition(".json")
+    loaded_json = load_json(path, dir)
+    stat_translations[name] = loaded_json
+    return loaded_json
+
+
+strongbox = _load_json_and_add_to_stat_translations("strongbox.json", __STAT_TRANSLATION_PATH__)
+support_gem = _load_json_and_add_to_stat_translations("support_gem.json", __STAT_TRANSLATION_PATH__)
+skill = _load_json_and_add_to_stat_translations("skill.json", __STAT_TRANSLATION_PATH__)
+aura_skill = _load_json_and_add_to_stat_translations("aura_skill.json", __STAT_TRANSLATION_PATH__)
+banner_aura_skill = _load_json_and_add_to_stat_translations("banner_aura_skill.json", __STAT_TRANSLATION_PATH__)
+beam_skill = _load_json_and_add_to_stat_translations("beam_skill.json", __STAT_TRANSLATION_PATH__)
+brand_skill = _load_json_and_add_to_stat_translations("brand_skill.json", __STAT_TRANSLATION_PATH__)
+buff_skill = _load_json_and_add_to_stat_translations("buff_skill.json", __STAT_TRANSLATION_PATH__)
+curse_skill = _load_json_and_add_to_stat_translations("curse_skill.json", __STAT_TRANSLATION_PATH__)
+debuff_skill = _load_json_and_add_to_stat_translations("debuff_skill.json", __STAT_TRANSLATION_PATH__)
+minion_skill = _load_json_and_add_to_stat_translations("minion_skill.json", __STAT_TRANSLATION_PATH__)
+minion_attack_skill = _load_json_and_add_to_stat_translations("minion_attack_skill.json", __STAT_TRANSLATION_PATH__)
+minion_spell_skill = _load_json_and_add_to_stat_translations("minion_spell_skill.json", __STAT_TRANSLATION_PATH__)
+offering_skill = _load_json_and_add_to_stat_translations("offering_skill.json", __STAT_TRANSLATION_PATH__)
+variable_duration_skill = _load_json_and_add_to_stat_translations(
+    "variable_duration_skill.json", __STAT_TRANSLATION_PATH__
+)
+areas = _load_json_and_add_to_stat_translations("areas.json", __STAT_TRANSLATION_PATH__)
+atlas = _load_json_and_add_to_stat_translations("atlas.json", __STAT_TRANSLATION_PATH__)
+passive_skill = _load_json_and_add_to_stat_translations("passive_skill.json", __STAT_TRANSLATION_PATH__)
+passive_skill_aura = _load_json_and_add_to_stat_translations("passive_skill_aura.json", __STAT_TRANSLATION_PATH__)
+monster = _load_json_and_add_to_stat_translations("monster.json", __STAT_TRANSLATION_PATH__)
+
 
 _assert_all_json_files_accounted_for(__STAT_TRANSLATION_PATH__)

--- a/RePoE/stat_translations.py
+++ b/RePoE/stat_translations.py
@@ -25,4 +25,27 @@ passive_skill = load_json("passive_skill.json", __STAT_TRANSLATION_PATH__)
 passive_skill_aura = load_json("passive_skill_aura.json", __STAT_TRANSLATION_PATH__)
 monster = load_json("monster.json", __STAT_TRANSLATION_PATH__)
 
+all = [
+    strongbox,
+    support_gem,
+    skill,
+    aura_skill,
+    banner_aura_skill,
+    beam_skill,
+    brand_skill,
+    buff_skill,
+    curse_skill,
+    debuff_skill,
+    minion_skill,
+    minion_attack_skill,
+    minion_spell_skill,
+    offering_skill,
+    variable_duration_skill,
+    areas,
+    atlas,
+    passive_skill,
+    passive_skill_aura,
+    monster,
+]
+
 _assert_all_json_files_accounted_for(__STAT_TRANSLATION_PATH__)

--- a/RePoE/stat_translations.py
+++ b/RePoE/stat_translations.py
@@ -1,0 +1,28 @@
+"""A module to handle importing the specific stat_translation jsons"""
+from RePoE import load_json, _assert_all_json_files_accounted_for, _get_all_json_files, __DATA_PATH__
+import os
+
+__STAT_TRANSLATION_PATH__ = os.path.join(__DATA_PATH__, "stat_translations", "")
+
+strongbox = load_json("strongbox.json", __STAT_TRANSLATION_PATH__)
+support_gem = load_json("support_gem.json", __STAT_TRANSLATION_PATH__)
+skill = load_json("skill.json", __STAT_TRANSLATION_PATH__)
+aura_skill = load_json("aura_skill.json", __STAT_TRANSLATION_PATH__)
+banner_aura_skill = load_json("banner_aura_skill.json", __STAT_TRANSLATION_PATH__)
+beam_skill = load_json("beam_skill.json", __STAT_TRANSLATION_PATH__)
+brand_skill = load_json("brand_skill.json", __STAT_TRANSLATION_PATH__)
+buff_skill = load_json("buff_skill.json", __STAT_TRANSLATION_PATH__)
+curse_skill = load_json("curse_skill.json", __STAT_TRANSLATION_PATH__)
+debuff_skill = load_json("debuff_skill.json", __STAT_TRANSLATION_PATH__)
+minion_skill = load_json("minion_skill.json", __STAT_TRANSLATION_PATH__)
+minion_attack_skill = load_json("minion_attack_skill.json", __STAT_TRANSLATION_PATH__)
+minion_spell_skill = load_json("minion_spell_skill.json", __STAT_TRANSLATION_PATH__)
+offering_skill = load_json("offering_skill.json", __STAT_TRANSLATION_PATH__)
+variable_duration_skill = load_json("variable_duration_skill.json", __STAT_TRANSLATION_PATH__)
+areas = load_json("areas.json", __STAT_TRANSLATION_PATH__)
+atlas = load_json("atlas.json", __STAT_TRANSLATION_PATH__)
+passive_skill = load_json("passive_skill.json", __STAT_TRANSLATION_PATH__)
+passive_skill_aura = load_json("passive_skill_aura.json", __STAT_TRANSLATION_PATH__)
+monster = load_json("monster.json", __STAT_TRANSLATION_PATH__)
+
+_assert_all_json_files_accounted_for(__STAT_TRANSLATION_PATH__)


### PR DESCRIPTION
can now do things like
`from RePoE.stat_translations import areas, minion_skill`

or can do
`from RePoE.stat_translations import stat_translations` to get a dict with all the stat_translations

one thing that isn't great about this design is 
`from RePoE import stat_translations` imports the json `stat_translations` while `from RePoE.stat_translations import ...` imports things from the subdirectory.

perhaps a better naming scheme would be more clear here?